### PR TITLE
snippet for python3 added

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ Hosted by [Nagarro](https://www.nagarro.com/de).
 Serve the cloned directory with a simple http server such as
 
 ```[bash]
+# python3
+python -m SimpleHTTPServer
+```
+
+```[bash]
+# python2
 python -m http.server
 ```
 


### PR DESCRIPTION
python2 should be obsolete, but I have only added python3 and left python2 as it is.
If python2 is considered obsolete, python2 can of course be removed.

I wish you much success at the GDCR in Vienna, have fun!
